### PR TITLE
repository and wait_for_completion variables not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Default: false
 String.  Path to configuration file. You must ensure that the directory path exists.
 Default: '/root/.curator/curator.yml'
 
-#####`action_file`
+#####`actions_file`
 String.  Path to actions file. You must ensure that the directory path exists.
 Default: '/root/.curator/actions.yml'
 

--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -126,7 +126,7 @@ define curator::action (
     fail('$key can be set only for action = allocation')
   }
 
-  if $repository and member(['delete_snapshots', 'snapshot',], $action) {
+  if $repository and !member(['delete_snapshots', 'snapshot',], $action) {
     fail('$repository can be set only for action = delete_snapshots or snapshot')
   }
 

--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -126,7 +126,7 @@ define curator::action (
     fail('$key can be set only for action = allocation')
   }
 
-  if $repository and !member(['delete_snapshots', 'snapshot',], $repository) {
+  if $repository and member(['delete_snapshots', 'snapshot',], $action) {
     fail('$repository can be set only for action = delete_snapshots or snapshot')
   }
 
@@ -134,7 +134,7 @@ define curator::action (
     fail('$retry_count can be set only for action = delete_snapshots')
   }
 
-  if $wait_for_completion and !member(['allocation', 'replicas', 'restore', 'snapshot'], $wait_for_completion) {
+  if $wait_for_completion and !member(['allocation', 'replicas', 'restore', 'snapshot'], $action) {
     fail('$wait_for_completion can be set only for action = allocation or replicas or restore or snapshot')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@
 #   String.  Path to configuration file. You must ensure that the directory path exists.
 #   Default: '/root/.curator/curator.yml'
 #
-# [*action_file*]
+# [*actions_file*]
 #   String.  Path to actions file. You must ensure that the directory path exists.
 #   Default: '/root/.curator/actions.yml'
 #


### PR DESCRIPTION
Hi there,

There seems to be a bug in the code that prevents the repository and wait_for_completion variables on the curator::action define to work with members.

For example the following code:

```
  curator::action { 'logstash_snapshot_indices':
    action                        => 'snapshot',
    wait_for_completion => 'True',
    repository                 => 's3-bucket',
```

Won't work because the code is referring to the wrong variable:

```
if $repository and !member(['delete_snapshots', 'snapshot',], $repository) {
```

Breaking into:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, $repository can be set only for action = delete_snapshots or snapshot at /etc/puppetlabs/code/environments/ops/modules/curator/manifests/action.pp:130:5 at /etc/puppetlabs/code/environments/ops/modules/profile_elasticsearch/manifests/backup.pp:58 on node XXXX
Warning: Not using cache on failed catalog
```

Here's the PR to fix that, I have also made some changes on the README.md file to point to the proper actions_file var on init.pp

Please let me know if you have any concerns!

Regards!
