### PR TITLE
fix log_level configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@
 #            and will only continue running on the node that is the elected master.
 #   Default: False
 #
-# [*loglevel*]
+# [*log_level*]
 #   String.  Set the minimum acceptable log severity to display. This should be CRITICAL, ERROR, WARNING, INFO, DEBUG, or left empty.
 #   Default: INFO
 #

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -24,7 +24,7 @@ client:
   master_only: <%= scope['curator::master_only'] %>
 
 logging:
-  loglevel: <%= scope['curator::loglevel'] %>
+  loglevel: <%= scope['curator::log_level'] %>
   logfile: <%= scope['curator::logfile'] %>
   logformat: <%= scope['curator::logformat'] %>
   blacklist: [<%= Array(scope['curator::blacklist']).join(", ") %>]


### PR DESCRIPTION
The loglevel configuration is stored in the "log_level" parameter (not "loglevel", which is reserved in Puppet).