### PR TITLE
remove unnecessary package/provider logic

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,29 +160,6 @@ class curator (
     }
   }
 
-  case $manage_repo {
-    true: {
-      case $::osfamily {
-        'Debian': {
-          $_package_name = 'python-elasticsearch-curator'
-          $_provider     = 'apt'
-        }
-        'RedHat': {
-          $_package_name = 'python-elasticsearch-curator'
-          $_provider     = 'yum'
-        }
-        default: {
-          $_package_name = 'elasticsearch-curator'
-          $_provider     = 'pip'
-        }
-      }
-    }
-    default: {
-      $_package_name = $package_name
-      $_provider     = $package_provider
-    }
-  }
-
   validate_bool($manage_repo)
 
   if ($manage_repo == true) {
@@ -190,14 +167,13 @@ class curator (
 
     # Set up repositories
     class { '::curator::repo': } ->
-    package { $_package_name:
-      ensure   => $ensure,
-      provider => $_provider,
+    package { $package_name:
+      ensure => $ensure,
     }
   } else {
-    package { $_package_name:
+    package { $package_name:
       ensure   => $ensure,
-      provider => $_provider,
+      provider => $package_provider,
     }
   }
 
@@ -207,7 +183,7 @@ class curator (
     group   => 'root',
     mode    => '0644',
     content => template("${module_name}/config.erb"),
-    require => Package[$_package_name],
+    require => Package[$package_name],
   }
 
   concat { $actions_file:


### PR DESCRIPTION
This keeps the default behavior of installing from pip. Besides removing some unnecessary code (Puppet can figure out the correct package provider to use for the OSs supported by this module), this fixes some issues with installing from repos, as Elastic stopped naming the binary package "python-elasticseach-curator" and switched to "elasticsearch-curator" around version 4.1.2:

```
$ yum --showduplicates list python-elasticsearch-curator 
Loaded plugins: fastestmirror
Determining fastest mirrors
 * base: mirrors.usinternet.com
 * epel: mirror.nexcess.net
 * extras: mirror.steadfast.net
 * updates: mirrors.umflint.edu
curator                                                                                                                                              36/36
nexcess/7/x86_64/primary                                                                                                            |  13 kB  00:00:00     
nexcess                                                                                                                                              44/44
Available Packages
python-elasticsearch-curator.noarch                                                     4.0.0-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.0.1-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.0.3-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.0.4-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.0.5-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.0.6-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.1.0-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.1.1-1                                                     curator
python-elasticsearch-curator.noarch                                                     4.1.2-1                                                     curator

$ yum --showduplicates list elasticsearch-curator 
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirrors.usinternet.com
 * epel: mirror.nexcess.net
 * extras: mirror.steadfast.net
 * updates: mirrors.umflint.edu
Available Packages
elasticsearch-curator.x86_64                                                        4.1.2-1                                                         curator
elasticsearch-curator.x86_64                                                        4.2.1-1                                                         curator
elasticsearch-curator.x86_64                                                        4.2.3-1                                                         curator
elasticsearch-curator.x86_64
```
They use elasticsearch-curator now:
https://www.elastic.co/guide/en/elasticsearch/client/curator/current/yum-repository.html
https://www.elastic.co/guide/en/elasticsearch/client/curator/current/apt-repository.html

The old python-elasticsearch-curator package from Elastic's also pulls in their own python-pyyaml RPM, which conflicts with the PyYAML rpm provided in the base repo of CentOS.

Tested this on Centos 7 & Ubuntu 14.04/16.04 without any problems.