### PR TITLE
Resolves conflicts with other modules

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class curator::config {
     mode  => '0644'
   }
 
-  concat::fragment { 'header':
+  concat::fragment { 'curator.config.header':
     target  => $curator::actions_file,
     content => template("${module_name}/actions_header.erb"),
     order   => '00',


### PR DESCRIPTION
Resolves "Duplicate declaration: Concat::Fragment[header] is already declared in file..."