### PR TITLE
Fix missing folder; Update repo before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Overview
 
 A puppet module for installing and configuring [elastic-curator](https://github.com/elastic/curator).
-This module was forked from jlambert121-curator and updated dor curator4
+This module was forked from jlambert121-curator and updated for curator4
 
 ## Module Description
 
@@ -27,7 +27,11 @@ NOTE: If you are using curator < 4.0.0 use a previous version of this module.
 
 The original module allowed you to create various cron jobs for curator.
 
-The new module will only create the config file and one action file. Also, now it it your job to create the cron job:
+The new module will only create the config file, one action file and ensure the last folder of the path. 
+If there is more than one (folder-)level missing you will have to create that folders externally before this module runs. 
+e.g. "/etc/curator/my_settings/" you have to ensure that "/etc/curator" is present.
+
+Also, now it is your job to create the cron job:
 
 ```puppet
   cron { "curator_run":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,17 +1,33 @@
 class curator::config {
+
+  $path = dirname($curator::config_file)
+
+  file { $path:
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644'
+  }
+
   file { $curator::config_file:
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     content => template("${module_name}/config.erb"),
-    require => Package[$curator::package_name],
+    require => [
+      Package[$curator::package_name],
+      File[$path],
+    ],
   }
 
   concat { $curator::actions_file:
-    owner => 'root',
-    group => 'root',
-    mode  => '0644'
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => [
+      File[$path],
+    ]
   }
 
   concat::fragment { 'curator.config.header':

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -44,7 +44,7 @@ class curator::repo {
           src => false,
           deb => true
         }
-      }
+      } -> Class['apt::update'] -> Package[$curator::package_name]
     }
     'RedHat': {
       # Support for facter 3


### PR DESCRIPTION
On puppet 4.x the module will not work because the folder (e.g.
/root/.curator) is missing and no requirement in the module for files in
that folder.